### PR TITLE
EAMxx: (MAM4xx) Adds gas dry deposition call in aerosol microphysics

### DIFF
--- a/components/eamxx/cime_config/namelist_defaults_scream.xml
+++ b/components/eamxx/cime_config/namelist_defaults_scream.xml
@@ -248,7 +248,7 @@ be lost if SCREAM_HACK_XML is not enabled.
     <!-- MAM4xx-ACI -->
     <mam4_aci inherit="atm_proc_base">
       <wsubmin type="real" doc="Minimum diagnostic sub-grid vertical velocity">0.001</wsubmin>
-      <enable_aero_vertical_mix type="logical" doc="Enable vertical mixing of interstitial aerosols and liquid number">false</enable_aero_vertical_mix>
+      <enable_aero_vertical_mix type="logical" doc="Enable vertical mixing of interstitial aerosols and liquid number during activation">true</enable_aero_vertical_mix>
       <top_level_mam4xx type="integer" doc="Level corresponding to the top of troposphere clouds" nlev="72"  >6</top_level_mam4xx>
       <top_level_mam4xx type="integer" doc="level corresponding to the top of troposphere clouds" nlev="128" >0</top_level_mam4xx>
     </mam4_aci>

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_functions.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_functions.hpp
@@ -17,7 +17,7 @@ void compute_w0_and_rho(haero::ThreadTeamPolicy team_policy,
   MAMAci::const_view_2d omega = dry_atmosphere.omega;
   MAMAci::const_view_2d T_mid = dry_atmosphere.T_mid;
   MAMAci::const_view_2d p_mid = dry_atmosphere.p_mid;
-  Kokkos::parallel_for(
+  Kokkos::parallel_for("scream::compute_w0_and_rho",
       team_policy, KOKKOS_LAMBDA(const haero::ThreadTeam &team) {
         const int icol = team.league_rank();
         // Get physical constants
@@ -46,7 +46,7 @@ void compute_tke_at_interfaces(haero::ThreadTeamPolicy team_policy,
 				  MAMAci::view_2d tke) {
   using CO = scream::ColumnOps<DefaultDevice, Real>;
 
-  Kokkos::parallel_for(
+  Kokkos::parallel_for("scream::compute_tke_at_interfaces",
       team_policy, KOKKOS_LAMBDA(const haero::ThreadTeam &team) {
         const int icol = team.league_rank();
 
@@ -73,7 +73,7 @@ void compute_subgrid_scale_velocities(
     const Real wsubmin, const int top_lev, const int nlev,
     // output
     MAMAci::view_2d wsub, MAMAci::view_2d wsubice, MAMAci::view_2d wsig) {
-  Kokkos::parallel_for(
+  Kokkos::parallel_for("scream::compute_subgrid_scale_velocities",
       team_policy, KOKKOS_LAMBDA(const haero::ThreadTeam &team) {
         const int icol = team.league_rank();
         // More refined computation of sub-grid vertical velocity
@@ -113,7 +113,7 @@ void compute_nucleate_ice_tendencies(
   // from ice nucleation
   //-------------------------------------------------------------
 
-  Kokkos::parallel_for(
+  Kokkos::parallel_for("scream::compute_nucleate_ice_tendencies",
       team_policy, KOKKOS_LAMBDA(const haero::ThreadTeam &team) {
         const int icol = team.league_rank();
         //---------------------------------------------------------------------
@@ -176,7 +176,7 @@ void store_liquid_cloud_fraction(
     MAMAci::view_2d cloud_frac, MAMAci::view_2d cloud_frac_prev) {
   MAMAci::const_view_2d qc = dry_atmosphere.qc;
   MAMAci::const_view_2d qi = dry_atmosphere.qi;
-  Kokkos::parallel_for(
+  Kokkos::parallel_for("scream::store_liquid_cloud_fraction",
       team_policy, KOKKOS_LAMBDA(const haero::ThreadTeam &team) {
         const int icol = team.league_rank();
         //-------------------------------------------------------------
@@ -320,7 +320,7 @@ void call_function_dropmixnuc(
   //---------------------------------------------------------------------------
   //---------------------------------------------------------------------------
   const bool local_enable_aero_vertical_mix = enable_aero_vertical_mix;
-  Kokkos::parallel_for(
+  Kokkos::parallel_for("scream::call_function_dropmixnuc",
       team_policy, KOKKOS_LAMBDA(const haero::ThreadTeam &team) {
         const int icol = team.league_rank();
         // for (int icol=0; icol<5; ++icol){
@@ -521,7 +521,7 @@ void call_hetfrz_compute_tendencies(
   for(int i = 0; i < MAMAci::hetro_scratch_; ++i)
     diagnostic_scratch[i] = diagnostic_scratch_[i];
 
-  Kokkos::parallel_for(
+  Kokkos::parallel_for("scream::call_hetfrz_compute_tendencies",
       team_policy, KOKKOS_LAMBDA(const haero::ThreadTeam &team) {
         const int icol = team.league_rank();
         //   Set up an atmosphere, surface, diagnostics, pronostics and

--- a/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_aci_process_interface.cpp
@@ -41,7 +41,7 @@ MAMAci::MAMAci(const ekat::Comm &comm, const ekat::ParameterList &params)
   EKAT_REQUIRE_MSG(m_params.isParameter("wsubmin"),
                    "ERROR: wsubmin is missing from mam_aci parameter list.");
   EKAT_REQUIRE_MSG(m_params.isParameter("enable_aero_vertical_mix"),
-                   "ERROR: enable_aero_vertical_mixing is missing from mam_aci "
+                   "ERROR: enable_aero_vertical_mix is missing from mam_aci "
                    "parameter list.");
   EKAT_REQUIRE_MSG(
       m_params.isParameter("top_level_mam4xx"),

--- a/components/eamxx/src/physics/mam/eamxx_mam_constituent_fluxes_functions.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_constituent_fluxes_functions.hpp
@@ -36,7 +36,7 @@ void update_gas_aerosols_using_constituents(
       get_default_team_policy(ncol, nconstituents);
 
   // Loop through all columns to update tracer mixing rations
-  Kokkos::parallel_for(
+  Kokkos::parallel_for("scream::update_gas_aerosols_using_constituents",
       policy, KOKKOS_LAMBDA(const haero::ThreadTeam &team) {
         const int icol = team.league_rank();
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_dry_deposition_functions.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_dry_deposition_functions.hpp
@@ -42,7 +42,7 @@ void compute_tendencies(
           ncol, nlev);
 
   // Parallel loop over all the columns
-  Kokkos::parallel_for(
+  Kokkos::parallel_for("scream::dry_deposition::compute_tendencies",
       policy, KOKKOS_LAMBDA(const MAMDryDep::KT::MemberType &team) {
         static constexpr int num_aero_species =
             mam_coupling::num_aero_species();
@@ -146,7 +146,7 @@ void update_interstitial_mmrs(const MAMDryDep::view_3d ptend_q, const double dt,
       ekat::ExeSpaceUtils<MAMDryDep::KT::ExeSpace>::get_default_team_policy(
           ncol, nlev);
   static constexpr int nmodes = mam4::AeroConfig::num_modes();
-  Kokkos::parallel_for(
+  Kokkos::parallel_for("scream::dry_deposition::update_interstitial_mmrs",
       policy, KOKKOS_LAMBDA(const MAMDryDep::KT::MemberType &team) {
         const int icol = team.league_rank();
         Kokkos::parallel_for(Kokkos::TeamVectorRange(team, nlev), [&](int kk) {

--- a/components/eamxx/src/physics/mam/eamxx_mam_dry_deposition_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_dry_deposition_process_interface.hpp
@@ -110,6 +110,7 @@ class MAMDryDep final : public scream::AtmosphereProcess {
   std::shared_ptr<AbstractRemapper> horizInterp_;
   std::shared_ptr<AtmosphereInput> dataReader_;
   const_view_2d frac_landuse_;
+  view_2d frac_landuse_fm_;
 
  public:
   using KT = ekat::KokkosTypes<DefaultDevice>;

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.cpp
@@ -1,10 +1,10 @@
+#include <mam4xx/mam4.hpp>
 #include <physics/mam/eamxx_mam_microphysics_process_interface.hpp>
-
 // impl namespace for some driver level functions for microphysics
 
-#include "readfiles/photo_table_utils.cpp"
-#include "readfiles/find_season_index_utils.hpp"
 #include "physics/rrtmgp/shr_orb_mod_c2f.hpp"
+#include "readfiles/find_season_index_utils.hpp"
+#include "readfiles/photo_table_utils.cpp"
 
 namespace scream {
 
@@ -36,7 +36,7 @@ MAMMicrophysics::MAMMicrophysics(const ekat::Comm &comm,
   config_.linoz.o3_lbl = m_params.get<int>("mam4_o3_lbl");
   config_.linoz.o3_tau = m_params.get<double>("mam4_o3_tau");
   config_.linoz.o3_sfc = m_params.get<double>("mam4_o3_sfc");
-  config_.linoz.psc_T = m_params.get<double>("mam4_psc_T");
+  config_.linoz.psc_T  = m_params.get<double>("mam4_psc_T");
 }
 
 AtmosphereProcessType MAMMicrophysics::type() const {
@@ -70,6 +70,9 @@ void MAMMicrophysics::set_grids(
   const FieldLayout scalar3d_mid = grid_->get_3d_scalar_layout(true);
   const FieldLayout scalar3d_int = grid_->get_3d_scalar_layout(false);
 
+  // For U and V components of wind
+  const FieldLayout vector3d = grid_->get_3d_vector_layout(true, 2);
+
   using namespace ekat::units;
   constexpr auto q_unit = kg / kg;  // units of mass mixing ratios of tracers
   constexpr auto n_unit = 1 / kg;   // units of number mixing ratios of tracers
@@ -81,19 +84,20 @@ void MAMMicrophysics::set_grids(
   // ----------- Atmospheric quantities -------------
 
   // Specific humidity [kg/kg](Require only for building DS)
-  add_tracer<Required>("qv", grid_, kg/kg); // specific humidity
+  add_tracer<Required>("qv", grid_, kg / kg);  // specific humidity
 
   // Cloud liquid mass mixing ratio [kg/kg](Require only for building DS)
-  add_tracer<Updated>("qc", grid_, kg/kg); // cloud liquid wet mixing ratio
+  add_tracer<Updated>("qc", grid_, kg / kg);  // cloud liquid wet mixing ratio
 
   // Cloud ice mass mixing ratio [kg/kg](Require only for building DS)
-  add_tracer<Required>("qi", grid_, kg/kg); // ice wet mixing ratio
+  add_tracer<Required>("qi", grid_, kg / kg);  // ice wet mixing ratio
 
   // Cloud liquid number mixing ratio [1/kg](Require only for building DS)
-  add_tracer<Updated>("nc", grid_, n_unit); // cloud liquid wet number mixing ratio
+  add_tracer<Updated>("nc", grid_,
+                      n_unit);  // cloud liquid wet number mixing ratio
 
   // Cloud ice number mixing ratio [1/kg](Require only for building DS)
-  add_tracer<Required>("ni", grid_, n_unit); // ice number mixing ratio
+  add_tracer<Required>("ni", grid_, n_unit);  // ice number mixing ratio
 
   // Temperature[K] at midpoints
   add_field<Required>("T_mid", scalar3d_mid, K, grid_name);
@@ -120,10 +124,29 @@ void MAMMicrophysics::set_grids(
   // Surface geopotential [m2/s2]
   add_field<Required>("phis", scalar2d, m2 / s2, grid_name);
 
+  // Surface pressure [Pa]
+  add_field<Required>("ps", scalar2d, Pa, grid_name);
+
+  // U and V components of the wind[m/s]
+  add_field<Required>("horiz_winds", vector3d, m / s, grid_name);
+
   //----------- Variables from microphysics scheme -------------
   constexpr auto nondim = ekat::units::Units::nondimensional();
   // Total cloud fraction [fraction]
   add_field<Required>("cldfrac_liq", scalar3d_mid, nondim, grid_name);
+
+  // Evaporation from stratiform rain [kg/kg/s]
+  add_field<Required>("nevapr", scalar3d_mid, kg / kg / s, grid_name);
+
+  // Stratiform rain production rate [kg/kg/s]
+  add_field<Required>("precip_total_tend", scalar3d_mid, kg / kg / s,
+                      grid_name);
+
+  // precipitation liquid mass [kg/m2]
+  add_field<Required>("precip_liq_surf_mass", scalar2d, kg / m2, grid_name);
+
+  // precipitation ice mass [kg/m2]
+  add_field<Required>("precip_ice_surf_mass", scalar2d, kg / m2, grid_name);
 
   //----------- Variables from other mam4xx processes ------------
   // Number of modes
@@ -142,18 +165,26 @@ void MAMMicrophysics::set_grids(
   // Wet density of interstitial aerosol [kg/m3]
   add_field<Required>("wetdens", scalar3d_mid_nmodes, kg / m3, grid_name);
 
-  //----------- Variables from coupler (land component)---------
+  // For fractional land use
+  const FieldLayout vector2d_class =
+      grid_->get_2d_vector_layout(mam4::mo_drydep::n_land_type, "class");
+
+  // Fractional land use [fraction]
+  add_field<Required>("fraction_landuse", vector2d_class, nondim, grid_name);
+
+  //----------- Variables from the coupler ---------
   // surface albedo shortwave, direct
   add_field<Required>("sfc_alb_dir_vis", scalar2d, nondim, grid_name);
 
-  //----------- Variables from microphysics scheme -------------
+  // Surface temperature[K]
+  add_field<Required>("surf_radiative_T", scalar2d, K, grid_name);
 
-  // Evaporation from stratiform rain [kg/kg/s]
-  add_field<Required>("nevapr", scalar3d_mid, kg / kg / s, grid_name);
+  // snow depth land [m]
+  add_field<Required>("snow_depth_land", scalar2d, m, grid_name);
 
-  // Stratiform rain production rate [kg/kg/s]
-  add_field<Required>("precip_total_tend", scalar3d_mid, kg / kg / s,
-                      grid_name);
+  //----------- Variables from the RRTMGP radiation ---------
+  // Downwelling solar flux at the surface [w/m2]
+  add_field<Required>("SW_flux_dn", scalar3d_int, W / m2, grid_name);
 
   // ---------------------------------------------------------------------
   // These variables are "updated" or inputs/outputs for the process
@@ -170,7 +201,7 @@ void MAMMicrophysics::set_grids(
           mam_coupling::int_aero_mmr_field_name(m, a);
 
       if(strlen(int_mmr_field_name) > 0) {
-        add_tracer<Updated>(int_mmr_field_name, grid_, kg/kg);
+        add_tracer<Updated>(int_mmr_field_name, grid_, kg / kg);
       }
     }  // for loop species
   }    // for loop nmodes interstitial
@@ -192,8 +223,16 @@ void MAMMicrophysics::set_grids(
   // aerosol-related gases: mass mixing ratios
   for(int g = 0; g < mam_coupling::num_aero_gases(); ++g) {
     const char *gas_mmr_field_name = mam_coupling::gas_mmr_field_name(g);
-    add_tracer<Updated>(gas_mmr_field_name, grid_, kg/kg);
+    add_tracer<Updated>(gas_mmr_field_name, grid_, kg / kg);
   }
+  //----------- Updated variables from other mam4xx processes ------------
+  // layout for Constituent fluxes
+  FieldLayout scalar2d_pcnst =
+      grid_->get_2d_vector_layout(mam4::pcnst, "num_phys_constituents");
+
+  // Constituent fluxes of species in [kg/m2/s]
+  add_field<Updated>("constituent_fluxes", scalar2d_pcnst, kg / m2 / s,
+                     grid_name);
 
   // Creating a Linoz reader and setting Linoz parameters involves reading data
   // from a file and configuring the necessary parameters for the Linoz model.
@@ -272,8 +311,10 @@ void MAMMicrophysics::set_grids(
       const auto file_name  = m_params.get<std::string>(item_name);
       elevated_emis_file_name_[var_name] = file_name;
     }
-    elevated_emis_var_names_["so2"]    = {"BB", "ENE_ELEV", "IND_ELEV", "contvolc"};
-    elevated_emis_var_names_["so4_a1"] = {"BB", "ENE_ELEV", "IND_ELEV", "contvolc"};
+    elevated_emis_var_names_["so2"]    = {"BB", "ENE_ELEV", "IND_ELEV",
+                                          "contvolc"};
+    elevated_emis_var_names_["so4_a1"] = {"BB", "ENE_ELEV", "IND_ELEV",
+                                          "contvolc"};
     elevated_emis_var_names_["so4_a2"] = {"contvolc"};
     elevated_emis_var_names_["pom_a4"] = {"BB"};
     elevated_emis_var_names_["bc_a4"]  = {"BB"};
@@ -285,8 +326,8 @@ void MAMMicrophysics::set_grids(
     // FIXME: why the sectors in this files are num_a1;
     //  I guess this should be num_a4? Is this a bug in the orginal nc files?
     elevated_emis_var_names_["num_a4"] = {"num_a1_BC_ELEV_BB",
-                                      "num_a1_POM_ELEV_BB"};
-    elevated_emis_var_names_["soag"]   = {"SOAbb_src", "SOAbg_src", "SOAff_src"};
+                                          "num_a1_POM_ELEV_BB"};
+    elevated_emis_var_names_["soag"] = {"SOAbb_src", "SOAbg_src", "SOAff_src"};
 
     int elevated_emiss_cyclical_ymd = m_params.get<int>("elevated_emiss_ymd");
 
@@ -300,9 +341,8 @@ void MAMMicrophysics::set_grids(
       auto hor_rem = scream::mam_coupling::create_horiz_remapper(
           grid_, file_name, extfrc_map_file, var_names, data_tracer);
 
-      auto file_reader =
-          scream::mam_coupling::create_tracer_data_reader(hor_rem, file_name,
-                                                          data_tracer.file_type);
+      auto file_reader = scream::mam_coupling::create_tracer_data_reader(
+          hor_rem, file_name, data_tracer.file_type);
       ElevatedEmissionsHorizInterp_.push_back(hor_rem);
       ElevatedEmissionsDataReader_.push_back(file_reader);
       elevated_emis_data_.push_back(data_tracer);
@@ -317,8 +357,9 @@ void MAMMicrophysics::set_grids(
       forcings_[i].nsectors = nvars;
       // I am assuming the order of species in extfrc_lst_.
       // Indexing in mam4xx is fortran.
-      forcings_[i].frc_ndx    = i + 1;
-      const auto io_grid_emis = ElevatedEmissionsHorizInterp_[i]->get_tgt_grid();
+      forcings_[i].frc_ndx = i + 1;
+      const auto io_grid_emis =
+          ElevatedEmissionsHorizInterp_[i]->get_tgt_grid();
       const int num_cols_io_emis =
           io_grid_emis->get_num_local_dofs();  // Number of columns on this rank
       const int num_levs_io_emis =
@@ -344,11 +385,11 @@ void MAMMicrophysics::set_grids(
   }  // Tracer external forcing data
 
   {
-    const std::string season_wes_file = m_params.get<std::string>("mam4_season_wes_file");
-    const auto& clat = col_latitudes_;
-    mam_coupling::find_season_index_reader(season_wes_file,
-                                         clat,
-                                         index_season_lai_);
+    const std::string season_wes_file =
+        m_params.get<std::string>("mam4_season_wes_file");
+    const auto &clat = col_latitudes_;
+    mam_coupling::find_season_index_reader(season_wes_file, clat,
+                                           index_season_lai_);
   }
 }  // set_grids
 
@@ -523,7 +564,7 @@ void MAMMicrophysics::initialize_impl(const RunType run_type) {
   work_photo_table_ = view_2d("work_photo_table", ncol_, photo_table_len);
   const int sethet_work_len = mam4::mo_sethet::get_total_work_len_sethet();
   work_set_het_ = view_2d("work_set_het_array", ncol_, sethet_work_len);
-  cmfdqr_ = view_1d("cmfdqr_", nlev_);
+  cmfdqr_       = view_1d("cmfdqr_", nlev_);
 
   // here's where we store per-column photolysis rates
   photo_rates_ = view_3d("photo_rates", ncol_, nlev_, mam4::mo_photo::phtcnt);
@@ -541,8 +582,8 @@ void MAMMicrophysics::initialize_impl(const RunType run_type) {
 
   for(int i = 0; i < static_cast<int>(extfrc_lst_.size()); ++i) {
     scream::mam_coupling::update_tracer_data_from_file(
-        ElevatedEmissionsDataReader_[i], curr_month, *ElevatedEmissionsHorizInterp_[i],
-        elevated_emis_data_[i]);
+        ElevatedEmissionsDataReader_[i], curr_month,
+        *ElevatedEmissionsHorizInterp_[i], elevated_emis_data_[i]);
   }
 
   invariants_ = view_3d("invarians", ncol_, nlev_, mam4::gas_chemistry::nfs);
@@ -568,28 +609,71 @@ void MAMMicrophysics::initialize_impl(const RunType run_type) {
 //  RUN_IMPL
 // ================================================================
 void MAMMicrophysics::run_impl(const double dt) {
+  const int ncol         = ncol_;
+  const int nlev         = nlev_;
   const auto scan_policy = ekat::ExeSpaceUtils<
-      KT::ExeSpace>::get_thread_range_parallel_scan_team_policy(ncol_, nlev_);
+      KT::ExeSpace>::get_thread_range_parallel_scan_team_policy(ncol, nlev);
   const auto policy =
-      ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(ncol_, nlev_);
+      ekat::ExeSpaceUtils<KT::ExeSpace>::get_default_team_policy(ncol, nlev);
 
   // preprocess input -- needs a scan for the calculation of atm height
   Kokkos::parallel_for("preprocess", scan_policy, preprocess_);
   Kokkos::fence();
 
-   //----------- Variables from microphysics scheme -------------
+  //----------- Variables from microphysics scheme -------------
 
   // Evaporation from stratiform rain [kg/kg/s]
-  const auto& nevapr = get_field_in("nevapr").get_view<const Real **>();
+  const auto &nevapr = get_field_in("nevapr").get_view<const Real **>();
 
   // Stratiform rain production rate [kg/kg/s]
-  const auto& prain = get_field_in("precip_total_tend").get_view<const Real **>();
+  const auto &prain =
+      get_field_in("precip_total_tend").get_view<const Real **>();
 
   const auto wet_geometric_mean_diameter_i =
       get_field_in("dgnumwet").get_view<const Real ***>();
   const auto dry_geometric_mean_diameter_i =
       get_field_in("dgnum").get_view<const Real ***>();
   const auto wetdens = get_field_in("wetdens").get_view<const Real ***>();
+
+  // U wind component [m/s]
+  const const_view_2d u_wind =
+      get_field_in("horiz_winds").get_component(0).get_view<const Real **>();
+
+  // V wind component [m/s]
+  const const_view_2d v_wind =
+      get_field_in("horiz_winds").get_component(1).get_view<const Real **>();
+
+  // Liquid precip [kg/m2]
+  const const_view_1d precip_liq_surf_mass =
+      get_field_in("precip_liq_surf_mass").get_view<const Real *>();
+
+  // Ice precip [kg/m2]
+  const const_view_1d precip_ice_surf_mass =
+      get_field_in("precip_ice_surf_mass").get_view<const Real *>();
+
+  // Fractional land use [fraction]
+  const const_view_2d fraction_landuse =
+      get_field_in("fraction_landuse").get_view<const Real **>();
+
+  // Downwelling solar flux at the surface [w/m2]
+  const const_view_2d sw_flux_dn =
+      get_field_in("SW_flux_dn").get_view<const Real **>();
+
+  // Constituent fluxes of gas and aerosol species
+  view_2d constituent_fluxes =
+      get_field_out("constituent_fluxes").get_view<Real **>();
+
+  // Surface temperature [K]
+  const const_view_1d sfc_temperature =
+      get_field_in("surf_radiative_T").get_view<const Real *>();
+
+  // Surface pressure [Pa]
+  const const_view_1d sfc_pressure =
+      get_field_in("ps").get_view<const Real *>();
+
+  // Snow depth on land [m]
+  const const_view_1d snow_depth_land =
+      get_field_in("snow_depth_land").get_view<const Real *>();
 
   // climatology data for linear stratospheric chemistry
   // ozone (climatology) [vmr]
@@ -648,14 +732,15 @@ void MAMMicrophysics::run_impl(const double dt) {
   Kokkos::fence();
 
   elevated_emiss_time_state_.t_now = ts.frac_of_year_in_days();
-  int i                        = 0;
+  int i                            = 0;
   for(const auto &var_name : extfrc_lst_) {
     const auto file_name = elevated_emis_file_name_[var_name];
     const auto var_names = elevated_emis_var_names_[var_name];
     const int nsectors   = int(var_names.size());
     view_2d elevated_emis_output[nsectors];
     for(int isp = 0; isp < nsectors; ++isp) {
-      elevated_emis_output[isp] = elevated_emis_output_[isp + forcings_[i].offset];
+      elevated_emis_output[isp] =
+          elevated_emis_output_[isp + forcings_[i].offset];
     }
     scream::mam_coupling::advance_tracer_data(
         ElevatedEmissionsDataReader_[i], *ElevatedEmissionsHorizInterp_[i], ts,
@@ -722,7 +807,7 @@ void MAMMicrophysics::run_impl(const double dt) {
     // then deep copied to a device view.
 
     // Now use solar declination to calculate zenith angle for all points
-    for(int i = 0; i < ncol_; i++) {
+    for(int i = 0; i < ncol; i++) {
       Real lat =
           col_latitudes_host(i) * M_PI / 180.0;  // Convert lat/lon to radians
       Real lon = col_longitudes_host(i) * M_PI / 180.0;
@@ -735,10 +820,10 @@ void MAMMicrophysics::run_impl(const double dt) {
   const auto zenith_angle = acos_cosine_zenith_;
   constexpr int gas_pcnst = mam_coupling::gas_pcnst();
 
-  const auto& elevated_emis_output = elevated_emis_output_;
-  const auto& extfrc           = extfrc_;
-  const auto& forcings         = forcings_;
-  constexpr int extcnt        = mam4::gas_chemistry::extcnt;
+  const auto &elevated_emis_output = elevated_emis_output_;
+  const auto &extfrc              = extfrc_;
+  const auto &forcings            = forcings_;
+  constexpr int extcnt            = mam4::gas_chemistry::extcnt;
 
   const int offset_aerosol = mam4::utils::gasses_start_ind();
   Real adv_mass_kg_per_moles[gas_pcnst];
@@ -753,11 +838,19 @@ void MAMMicrophysics::run_impl(const double dt) {
     clsmap_4[i]              = mam4::gas_chemistry::clsmap_4[i];
     permute_4[i]             = mam4::gas_chemistry::permute_4[i];
   }
-  const auto& cmfdqr = cmfdqr_;
-  const auto& work_set_het =work_set_het_;
+  const auto &cmfdqr       = cmfdqr_;
+  const auto &work_set_het = work_set_het_;
+  const mam4::seq_drydep::Data drydep_data =
+      mam4::seq_drydep::set_gas_drydep_data();
+  const auto qv         = wet_atm_.qv;
+  const int month       = timestamp().get_month();  // 1-based
+  const int surface_lev = nlev - 1;                 // Surface level
+  const auto & index_season_lai= index_season_lai_;
+
   // loop over atmosphere columns and compute aerosol microphyscs
   Kokkos::parallel_for(
-      policy, KOKKOS_LAMBDA(const ThreadTeam &team) {
+      "MAMMicrophysics::run_impl", policy,
+      KOKKOS_LAMBDA(const ThreadTeam &team) {
         const int icol     = team.league_rank();   // column index
         const Real col_lat = col_latitudes(icol);  // column latitude (degrees?)
 
@@ -820,28 +913,86 @@ void MAMMicrophysics::run_impl(const double dt) {
             ekat::subview(linoz_dPmL_dO3col, icol);
         const auto linoz_cariolle_pscs_icol =
             ekat::subview(linoz_cariolle_pscs, icol);
-        const auto nevapr_icol  = ekat::subview(nevapr, icol);
-        const auto prain_icol = ekat::subview(prain, icol);
+        const auto nevapr_icol       = ekat::subview(nevapr, icol);
+        const auto prain_icol        = ekat::subview(prain, icol);
         const auto work_set_het_icol = ekat::subview(work_set_het, icol);
-        // Note: All variables are inputs, except for progs, which is an
-        // input/output variable.
+
+        // Wind speed at the surface
+        const Real wind_speed =
+            haero::sqrt(u_wind(icol, surface_lev) * u_wind(icol, surface_lev) +
+                        v_wind(icol, surface_lev) * v_wind(icol, surface_lev));
+
+        // Total rain at the surface
+        const Real rain = precip_liq_surf_mass(icol) +
+                          precip_ice_surf_mass(icol);
+
+        // Snow depth on land [m]
+        const Real snow_height = snow_depth_land(icol);
+
+        // Downwelling solar flux at the surface (value at interface) [w/m2]
+        const Real solar_flux = sw_flux_dn(icol, surface_lev + 1);
+
+        Real fraction_landuse_icol[mam4::mo_drydep::n_land_type];
+        for(int i = 0; i < mam4::mo_drydep::n_land_type; ++i) {
+          fraction_landuse_icol[i] = fraction_landuse(icol, i);
+        }
+    int index_season[mam4::mo_drydep::n_land_type];
+  {
+
+       //-------------------------------------------------------------------------------------
+  // define which season (relative to Northern hemisphere climate)
+  //-------------------------------------------------------------------------------------
+
+  //-------------------------------------------------------------------------------------
+  // define season index based on fixed LAI
+  //-------------------------------------------------------------------------------------
+  for (int lt = 0; lt < mam4::mo_drydep::n_land_type; ++lt) {
+    index_season[lt] = index_season_lai(icol, month - 1);
+  }
+
+  //-------------------------------------------------------------------------------------
+  // special case for snow covered terrain
+  //-------------------------------------------------------------------------------------
+  if (snow_height > 0.01) { // BAD_CONSTANT
+    for (int lt = 0; lt < mam4::mo_drydep::n_land_type; ++lt) {
+      index_season[lt] = 3;
+    }
+  }
+
+    }
+        // These output values need to be put somewhere:
+        Real dvel[gas_pcnst] = {};  // deposition velocity [1/cm/s]
+        Real dflx[gas_pcnst] = {};  // deposition flux [1/cm^2/s]
+
+        // Output: values are dvel, dvlx
+        // Input/Output: progs::stateq, progs::qqcw
         mam4::microphysics::perform_atmospheric_chemistry_and_microphysics(
-            team, dt, rlats, cnst_offline_icol, forcings_in, atm, progs,
-            photo_table, chlorine_loading, config.setsox, config.amicphys,
-            config.linoz.psc_T, zenith_angle(icol), d_sfc_alb_dir_vis(icol),
-            o3_col_dens_i, photo_rates_icol, extfrc_icol, invariants_icol,
-            work_photo_table_icol, linoz_o3_clim_icol, linoz_t_clim_icol,
-            linoz_o3col_clim_icol, linoz_PmL_clim_icol, linoz_dPmL_dO3_icol,
-            linoz_dPmL_dT_icol, linoz_dPmL_dO3col_icol,
-            linoz_cariolle_pscs_icol, eccf, adv_mass_kg_per_moles, clsmap_4,
-            permute_4, offset_aerosol,
-            config.linoz.o3_sfc, config.linoz.o3_tau, config.linoz.o3_lbl,
-            dry_diameter_icol, wet_diameter_icol, wetdens_icol,
-            dry_atm.phis(icol),
-            cmfdqr,
-            prain_icol,
-            nevapr_icol,
-            work_set_het_icol);
+            team, dt, rlats, sfc_temperature(icol),
+            sfc_pressure(icol),
+            wind_speed, rain,
+            solar_flux, cnst_offline_icol,
+            forcings_in, atm, photo_table, chlorine_loading, config.setsox,
+            config.amicphys, config.linoz.psc_T, zenith_angle(icol),
+            d_sfc_alb_dir_vis(icol), o3_col_dens_i, photo_rates_icol,
+            extfrc_icol, invariants_icol, work_photo_table_icol,
+            linoz_o3_clim_icol, linoz_t_clim_icol, linoz_o3col_clim_icol,
+            linoz_PmL_clim_icol, linoz_dPmL_dO3_icol, linoz_dPmL_dT_icol,
+            linoz_dPmL_dO3col_icol, linoz_cariolle_pscs_icol, eccf,
+            adv_mass_kg_per_moles, fraction_landuse_icol,
+            index_season,
+            clsmap_4, permute_4, offset_aerosol, config.linoz.o3_sfc,
+            config.linoz.o3_tau, config.linoz.o3_lbl, dry_diameter_icol,
+            wet_diameter_icol, wetdens_icol, dry_atm.phis(icol), cmfdqr,
+            prain_icol, nevapr_icol, work_set_het_icol, drydep_data, dvel, dflx,
+            progs);
+
+        // Update constituent fluxes with gas drydep fluxes (dflx)
+        // FIXME: Possible units mismatch (dflx is in kg/cm2/s but
+        // constituent_fluxes is kg/m2/s) (Following mimics Fortran code
+        // behavior but we should look into it)
+        for(int ispc = offset_aerosol; ispc < mam4::pcnst; ++ispc) {
+          constituent_fluxes(icol, ispc) = dflx[ispc - offset_aerosol];
+        }
       });  // parallel_for for the column loop
   Kokkos::fence();
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.hpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_microphysics_process_interface.hpp
@@ -22,6 +22,7 @@ class MAMMicrophysics final : public scream::AtmosphereProcess {
   using view_2d       = typename KT::template view_2d<Real>;
   using view_3d       = typename KT::template view_3d<Real>;
   using const_view_1d = typename KT::template view_1d<const Real>;
+  using const_view_2d = typename KT::template view_2d<const Real>;
 
   using view_1d_host = typename KT::view_1d<Real>::HostMirror;
 

--- a/components/eamxx/src/physics/mam/eamxx_mam_optics_process_interface.cpp
+++ b/components/eamxx/src/physics/mam/eamxx_mam_optics_process_interface.cpp
@@ -399,7 +399,7 @@ void MAMOptics::run_impl(const double dt) {
   const auto &work                           = work_;
   const auto &dry_aero                       = dry_aero_;
   const auto &aerosol_optics_device_data     = aerosol_optics_device_data_;
-  Kokkos::parallel_for(
+  Kokkos::parallel_for("MAMOptics::run_impl",
       policy, KOKKOS_LAMBDA(const ThreadTeam &team) {
         const Int icol     = team.league_rank();  // column index
         // absorption optical depth, per layer [unitless]

--- a/components/eamxx/src/physics/mam/mam_coupling.hpp
+++ b/components/eamxx/src/physics/mam/mam_coupling.hpp
@@ -809,7 +809,7 @@ void compute_recipical_pseudo_density(haero::ThreadTeamPolicy team_policy,
                                       const int nlev,
                                       // output
                                       view_2d rpdel) {
-  Kokkos::parallel_for(
+  Kokkos::parallel_for("compute_recipical_pseudo_density",
       team_policy, KOKKOS_LAMBDA(const haero::ThreadTeam &team) {
         const int icol = team.league_rank();
         Kokkos::parallel_for(
@@ -828,7 +828,7 @@ void copy_view_lev_slice(haero::ThreadTeamPolicy team_policy, //inputs
                          const int dim,                       //dimension till view should be copied
                          view_2d &out_view) {                 //output view
 
-  Kokkos::parallel_for(
+  Kokkos::parallel_for("copy_view_lev_slice",
       team_policy, KOKKOS_LAMBDA(const haero::ThreadTeam &team) {
         const int icol = team.league_rank();
         Kokkos::parallel_for(Kokkos::TeamThreadRange(team, dim), [&](int kk) {

--- a/components/eamxx/src/physics/mam/srf_emission_impl.hpp
+++ b/components/eamxx/src/physics/mam/srf_emission_impl.hpp
@@ -127,7 +127,7 @@ void srfEmissFunctions<S, D>::perform_time_interpolation(
   using ESU          = ekat::ExeSpaceUtils<ExeSpace>;
   const auto policy  = ESU::get_default_team_policy(ncols, nsectors);
 
-  Kokkos::parallel_for(
+  Kokkos::parallel_for("srfEmissFunctions::perform_time_interpolation",
       policy, KOKKOS_LAMBDA(const MemberType &team) {
         const int icol = team.league_rank();  // column index
         Real accum     = 0;

--- a/components/eamxx/src/share/field/field_impl.hpp
+++ b/components/eamxx/src/share/field/field_impl.hpp
@@ -532,7 +532,7 @@ deep_copy_impl (const Field& src) const {
 
 template<HostOrDevice HD, typename ST>
 void Field::deep_copy_impl (const ST value) const {
-
+  Kokkos::Profiling::pushRegion("Field::deep_copy_impl");
   // Note: we can't just do a deep copy on get_view_impl<HD>(), since this
   //       field might be a subfield of another. Instead, get the
   //       reshaped view first, based on the field rank.
@@ -615,6 +615,7 @@ void Field::deep_copy_impl (const ST value) const {
     default:
       EKAT_ERROR_MSG ("Error! Unsupported field rank in 'deep_copy'.\n");
   }
+  Kokkos::Profiling::popRegion();
 }
 
 template<HostOrDevice HD, typename ST>

--- a/components/eamxx/src/share/property_checks/field_nan_check.cpp
+++ b/components/eamxx/src/share/property_checks/field_nan_check.cpp
@@ -50,7 +50,7 @@ PropertyCheck::ResultAndMsg FieldNaNCheck::check_impl() const {
     case 1:
       {
         auto v = f.template get_strided_view<const_ST*>();
-        Kokkos::parallel_reduce(size, KOKKOS_LAMBDA(int i, int& result) {
+        Kokkos::parallel_reduce("FieldNaNCheck::check_impl:case_1", size, KOKKOS_LAMBDA(int i, int& result) {
           if (ekat::is_invalid(v(i))) {
             result = i;
           }
@@ -60,7 +60,7 @@ PropertyCheck::ResultAndMsg FieldNaNCheck::check_impl() const {
     case 2:
       {
         auto v = f.template get_strided_view<const_ST**>();
-        Kokkos::parallel_reduce(size, KOKKOS_LAMBDA(int idx, int& result) {
+        Kokkos::parallel_reduce("FieldNaNCheck::check_impl:case_2", size, KOKKOS_LAMBDA(int idx, int& result) {
           int i,j;
           unflatten_idx(idx,extents,i,j);
           if (ekat::is_invalid(v(i,j))) {
@@ -72,7 +72,7 @@ PropertyCheck::ResultAndMsg FieldNaNCheck::check_impl() const {
     case 3:
       {
         auto v = f.template get_strided_view<const_ST***>();
-        Kokkos::parallel_reduce(size, KOKKOS_LAMBDA(int idx, int& result) {
+        Kokkos::parallel_reduce("FieldNaNCheck::check_impl:case_3", size, KOKKOS_LAMBDA(int idx, int& result) {
           int i,j,k;
           unflatten_idx(idx,extents,i,j,k);
           if (ekat::is_invalid(v(i,j,k))) {
@@ -84,7 +84,7 @@ PropertyCheck::ResultAndMsg FieldNaNCheck::check_impl() const {
     case 4:
       {
         auto v = f.template get_strided_view<const_ST****>();
-        Kokkos::parallel_reduce(size, KOKKOS_LAMBDA(int idx, int& result) {
+        Kokkos::parallel_reduce("FieldNaNCheck::check_impl:case_4", size, KOKKOS_LAMBDA(int idx, int& result) {
           int i,j,k,l;
           unflatten_idx(idx,extents,i,j,k,l);
           if (ekat::is_invalid(v(i,j,k,l))) {
@@ -96,7 +96,7 @@ PropertyCheck::ResultAndMsg FieldNaNCheck::check_impl() const {
     case 5:
       {
         auto v = f.template get_strided_view<const_ST*****>();
-        Kokkos::parallel_reduce(size, KOKKOS_LAMBDA(int idx, int& result) {
+        Kokkos::parallel_reduce("FieldNaNCheck::check_impl:case_5", size, KOKKOS_LAMBDA(int idx, int& result) {
           int i,j,k,l,m;
           unflatten_idx(idx,extents,i,j,k,l,m);
           if (ekat::is_invalid(v(i,j,k,l,m))) {
@@ -108,7 +108,7 @@ PropertyCheck::ResultAndMsg FieldNaNCheck::check_impl() const {
     case 6:
       {
         auto v = f.template get_strided_view<const_ST******>();
-        Kokkos::parallel_reduce(size, KOKKOS_LAMBDA(int idx, int& result) {
+        Kokkos::parallel_reduce("FieldNaNCheck::check_impl:case_6", size, KOKKOS_LAMBDA(int idx, int& result) {
           int i,j,k,l,m,n;
           unflatten_idx(idx,extents,i,j,k,l,m,n);
           if (ekat::is_invalid(v(i,j,k,l,m,n))) {

--- a/components/eamxx/src/share/property_checks/field_within_interval_check.cpp
+++ b/components/eamxx/src/share/property_checks/field_within_interval_check.cpp
@@ -95,7 +95,7 @@ PropertyCheck::ResultAndMsg FieldWithinIntervalCheck::check_impl () const
     case 1:
       {
         auto v = f.template get_view<const_ST*>();
-        Kokkos::parallel_reduce(size, KOKKOS_LAMBDA(int i, minmaxloc_value_t& result) {
+        Kokkos::parallel_reduce("FieldWithinIntervalCheck::check_impl:case_1", size, KOKKOS_LAMBDA(int i, minmaxloc_value_t& result) {
           if (v(i)<result.min_val) {
             result.min_val = v(i);
             result.min_loc = i;
@@ -110,7 +110,7 @@ PropertyCheck::ResultAndMsg FieldWithinIntervalCheck::check_impl () const
     case 2:
       {
         auto v = f.template get_view<const_ST**>();
-        Kokkos::parallel_reduce(size, KOKKOS_LAMBDA(int idx, minmaxloc_value_t& result) {
+        Kokkos::parallel_reduce("FieldWithinIntervalCheck::check_impl:case_2", size, KOKKOS_LAMBDA(int idx, minmaxloc_value_t& result) {
           int i,j;
           unflatten_idx(idx,extents,i,j);
           if (v(i,j)<result.min_val) {
@@ -127,7 +127,7 @@ PropertyCheck::ResultAndMsg FieldWithinIntervalCheck::check_impl () const
     case 3:
       {
         auto v = f.template get_view<const_ST***>();
-        Kokkos::parallel_reduce(size, KOKKOS_LAMBDA(int idx, minmaxloc_value_t& result) {
+        Kokkos::parallel_reduce("FieldWithinIntervalCheck::check_impl:case_3", size, KOKKOS_LAMBDA(int idx, minmaxloc_value_t& result) {
           int i,j,k;
           unflatten_idx(idx,extents,i,j,k);
           if (v(i,j,k)<result.min_val) {
@@ -144,7 +144,7 @@ PropertyCheck::ResultAndMsg FieldWithinIntervalCheck::check_impl () const
     case 4:
       {
         auto v = f.template get_view<const_ST****>();
-        Kokkos::parallel_reduce(size, KOKKOS_LAMBDA(int idx, minmaxloc_value_t& result) {
+        Kokkos::parallel_reduce("FieldWithinIntervalCheck::check_impl:case_4", size, KOKKOS_LAMBDA(int idx, minmaxloc_value_t& result) {
           int i,j,k,l;
           unflatten_idx(idx,extents,i,j,k,l);
           if (v(i,j,k,l)<result.min_val) {
@@ -161,7 +161,7 @@ PropertyCheck::ResultAndMsg FieldWithinIntervalCheck::check_impl () const
     case 5:
       {
         auto v = f.template get_view<const_ST*****>();
-        Kokkos::parallel_reduce(size, KOKKOS_LAMBDA(int idx, minmaxloc_value_t& result) {
+        Kokkos::parallel_reduce("FieldWithinIntervalCheck::check_impl:case_5", size, KOKKOS_LAMBDA(int idx, minmaxloc_value_t& result) {
           int i,j,k,l,m;
           unflatten_idx(idx,extents,i,j,k,l,m);
           if (v(i,j,k,l,m)<result.min_val) {
@@ -178,7 +178,7 @@ PropertyCheck::ResultAndMsg FieldWithinIntervalCheck::check_impl () const
     case 6:
       {
         auto v = f.template get_view<const_ST******>();
-        Kokkos::parallel_reduce(size, KOKKOS_LAMBDA(int idx, minmaxloc_value_t& result) {
+        Kokkos::parallel_reduce("FieldWithinIntervalCheck::check_impl:case_6", size, KOKKOS_LAMBDA(int idx, minmaxloc_value_t& result) {
           int i,j,k,l,m,n;
           unflatten_idx(idx,extents,i,j,k,l,m,n);
           if (v(i,j,k,l,m,n)<result.min_val) {
@@ -351,7 +351,7 @@ void FieldWithinIntervalCheck::repair_impl() const
     case 1:
       {
         auto v = f.template get_view<nonconst_ST*>();
-        Kokkos::parallel_for(size, KOKKOS_LAMBDA(int i) {
+        Kokkos::parallel_for("FieldWithinIntervalCheck::repair_impl:case_1", size, KOKKOS_LAMBDA(int i) {
           auto& ref = v(i);
           ref = ekat::impl::min(ub, ref);
           ref = ekat::impl::max(lb, ref);
@@ -361,7 +361,7 @@ void FieldWithinIntervalCheck::repair_impl() const
     case 2:
       {
         auto v = f.template get_view<nonconst_ST**>();
-        Kokkos::parallel_for(size, KOKKOS_LAMBDA(int idx) {
+        Kokkos::parallel_for("FieldWithinIntervalCheck::repair_impl:case_2", size, KOKKOS_LAMBDA(int idx) {
           int i,j;
           unflatten_idx(idx,extents,i,j);
 
@@ -374,7 +374,7 @@ void FieldWithinIntervalCheck::repair_impl() const
     case 3:
       {
         auto v = f.template get_view<nonconst_ST***>();
-        Kokkos::parallel_for(size, KOKKOS_LAMBDA(int idx) {
+        Kokkos::parallel_for("FieldWithinIntervalCheck::repair_impl:case_3", size, KOKKOS_LAMBDA(int idx) {
           int i,j,k;
           unflatten_idx(idx,extents,i,j,k);
 
@@ -387,7 +387,7 @@ void FieldWithinIntervalCheck::repair_impl() const
     case 4:
       {
         auto v = f.template get_view<nonconst_ST****>();
-        Kokkos::parallel_for(size, KOKKOS_LAMBDA(int idx) {
+        Kokkos::parallel_for("FieldWithinIntervalCheck::repair_impl:case_4", size, KOKKOS_LAMBDA(int idx) {
           int i,j,k,l;
           unflatten_idx(idx,extents,i,j,k,l);
 
@@ -400,7 +400,7 @@ void FieldWithinIntervalCheck::repair_impl() const
     case 5:
       {
         auto v = f.template get_view<nonconst_ST*****>();
-        Kokkos::parallel_for(size, KOKKOS_LAMBDA(int idx) {
+        Kokkos::parallel_for("FieldWithinIntervalCheck::repair_impl:case_5", size, KOKKOS_LAMBDA(int idx) {
           int i,j,k,l,m;
           unflatten_idx(idx,extents,i,j,k,l,m);
 
@@ -413,7 +413,7 @@ void FieldWithinIntervalCheck::repair_impl() const
     case 6:
       {
         auto v = f.template get_view<nonconst_ST******>();
-        Kokkos::parallel_for(size, KOKKOS_LAMBDA(int idx) {
+        Kokkos::parallel_for("FieldWithinIntervalCheck::repair_impl:case_6", size, KOKKOS_LAMBDA(int idx) {
           int i,j,k,l,m,n;
           unflatten_idx(idx,extents,i,j,k,l,m,n);
 

--- a/components/eamxx/src/share/property_checks/mass_and_energy_column_conservation_check.cpp
+++ b/components/eamxx/src/share/property_checks/mass_and_energy_column_conservation_check.cpp
@@ -63,7 +63,7 @@ void MassAndEnergyColumnConservationCheck::compute_current_mass ()
   const auto qr = m_fields.at("qr").get_view<const Real**>();
 
   const auto policy = ExeSpaceUtils::get_default_team_policy(ncols, nlevs);
-  Kokkos::parallel_for(policy, KOKKOS_LAMBDA (const KT::MemberType& team) {
+  Kokkos::parallel_for("MassAndEnergyColumnConservationCheck::compute_current_mass", policy, KOKKOS_LAMBDA (const KT::MemberType& team) {
     const int i = team.league_rank();
 
     const auto pseudo_density_i = ekat::subview(pseudo_density, i);
@@ -92,7 +92,7 @@ void MassAndEnergyColumnConservationCheck::compute_current_energy ()
   const auto phis = m_fields.at("phis").get_view<const Real*>();
 
   const auto policy = ExeSpaceUtils::get_default_team_policy(ncols, nlevs);
-  Kokkos::parallel_for(policy, KOKKOS_LAMBDA (const KT::MemberType& team) {
+  Kokkos::parallel_for("MassAndEnergyColumnConservationCheck::compute_current_energy", policy, KOKKOS_LAMBDA (const KT::MemberType& team) {
     const int i = team.league_rank();
 
     const auto pseudo_density_i = ekat::subview(pseudo_density, i);
@@ -141,7 +141,7 @@ PropertyCheck::ResultAndMsg MassAndEnergyColumnConservationCheck::check() const
 
   // Mass error calculation
   const auto policy = ExeSpaceUtils::get_default_team_policy(ncols, nlevs);
-  Kokkos::parallel_reduce(policy, KOKKOS_LAMBDA (const KT::MemberType& team,
+  Kokkos::parallel_reduce(" MassAndEnergyColumnConservationCheck::check:mass", policy, KOKKOS_LAMBDA (const KT::MemberType& team,
                                                  maxloc_value_t&       result) {
     const int i = team.league_rank();
 
@@ -173,7 +173,7 @@ PropertyCheck::ResultAndMsg MassAndEnergyColumnConservationCheck::check() const
   }, maxloc_t(maxloc_mass));
 
   // Energy error calculation
-  Kokkos::parallel_reduce(policy, KOKKOS_LAMBDA (const KT::MemberType& team,
+  Kokkos::parallel_reduce(" MassAndEnergyColumnConservationCheck::check:energy", policy, KOKKOS_LAMBDA (const KT::MemberType& team,
                                                  maxloc_value_t&       result) {
 
     const int i = team.league_rank();

--- a/components/eamxx/tests/multi-process/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/multi-process/dynamics_physics/homme_shoc_cld_p3_rrtmgp/input.yaml
@@ -19,6 +19,9 @@ initial_conditions:
   surf_sens_flux: 0.0
   precip_liq_surf_mass: 0.0
   precip_ice_surf_mass: 0.0
+  hetfrz_immersion_nucleation_tend: 0.1
+  hetfrz_contact_nucleation_tend: 0.1
+  hetfrz_deposition_nucleation_tend: 0.1
 
 atmosphere_processes:
   atm_procs_list: [homme,physics]

--- a/components/eamxx/tests/multi-process/dynamics_physics/homme_shoc_cld_p3_rrtmgp_pg2/input.yaml
+++ b/components/eamxx/tests/multi-process/dynamics_physics/homme_shoc_cld_p3_rrtmgp_pg2/input.yaml
@@ -15,6 +15,9 @@ initial_conditions:
   surf_sens_flux: 0.0
   precip_liq_surf_mass: 0.0
   precip_ice_surf_mass: 0.0
+  hetfrz_immersion_nucleation_tend: 0.1
+  hetfrz_contact_nucleation_tend: 0.1
+  hetfrz_deposition_nucleation_tend: 0.1
   surf_lw_flux_up: 400.0
   eddy_diff_mom: 0.02
   sgs_buoy_flux: -0.001

--- a/components/eamxx/tests/multi-process/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/multi-process/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -15,6 +15,9 @@ initial_conditions:
   surf_sens_flux: 0.0
   precip_liq_surf_mass: 0.0
   precip_ice_surf_mass: 0.0
+  hetfrz_immersion_nucleation_tend: 0.1
+  hetfrz_contact_nucleation_tend: 0.1
+  hetfrz_deposition_nucleation_tend: 0.1
 
 atmosphere_processes:
   atm_procs_list: [homme,physics]

--- a/components/eamxx/tests/multi-process/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
+++ b/components/eamxx/tests/multi-process/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_128levels/input.yaml
@@ -15,6 +15,9 @@ initial_conditions:
   surf_sens_flux: 0.0
   precip_ice_surf_mass: 0.0
   precip_liq_surf_mass: 0.0
+  hetfrz_immersion_nucleation_tend: 0.1
+  hetfrz_contact_nucleation_tend: 0.1
+  hetfrz_deposition_nucleation_tend: 0.1
 
 atmosphere_processes:
   atm_procs_list: [homme,physics]

--- a/components/eamxx/tests/multi-process/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_pg2_dp/input.yaml
+++ b/components/eamxx/tests/multi-process/dynamics_physics/homme_shoc_cld_spa_p3_rrtmgp_pg2_dp/input.yaml
@@ -33,6 +33,9 @@ initial_conditions:
   surf_lw_flux_up: 400.0
   eddy_diff_mom: 0.02
   sgs_buoy_flux: -0.001
+  hetfrz_immersion_nucleation_tend: 0.1
+  hetfrz_contact_nucleation_tend: 0.1
+  hetfrz_deposition_nucleation_tend: 0.1
 
 atmosphere_processes:
   atm_procs_list: [sc_import,homme,physics]

--- a/components/eamxx/tests/multi-process/dynamics_physics/mam/homme_shoc_cld_mam_aci_p3_mam_optics_rrtmgp_mam_drydep/input.yaml
+++ b/components/eamxx/tests/multi-process/dynamics_physics/mam/homme_shoc_cld_mam_aci_p3_mam_optics_rrtmgp_mam_drydep/input.yaml
@@ -25,6 +25,9 @@ initial_conditions:
   #variables required for p3
   precip_ice_surf_mass: 0.0
   precip_liq_surf_mass: 0.0
+  hetfrz_immersion_nucleation_tend: 0.1
+  hetfrz_contact_nucleation_tend: 0.1
+  hetfrz_deposition_nucleation_tend: 0.1
 
   #variables required for mam4_aci
   dgnum: 1e-3

--- a/components/eamxx/tests/multi-process/dynamics_physics/mam/homme_shoc_cld_mam_aci_p3_mam_optics_rrtmgp_mam_drydep/input.yaml
+++ b/components/eamxx/tests/multi-process/dynamics_physics/mam/homme_shoc_cld_mam_aci_p3_mam_optics_rrtmgp_mam_drydep/input.yaml
@@ -54,6 +54,7 @@ atmosphere_processes:
       number_of_subcycles: ${MAC_MIC_SUBCYCLES}
       mam4_aci:
         wsubmin: 0.001
+        enable_aero_vertical_mix: true
         top_level_mam4xx: 6
       p3:
         do_prescribed_ccn: false

--- a/components/eamxx/tests/multi-process/dynamics_physics/mam/homme_shoc_cld_p3_mam_optics_rrtmgp/input.yaml
+++ b/components/eamxx/tests/multi-process/dynamics_physics/mam/homme_shoc_cld_p3_mam_optics_rrtmgp/input.yaml
@@ -19,6 +19,9 @@ initial_conditions:
   surf_sens_flux: 0.0
   precip_liq_surf_mass: 0.0
   precip_ice_surf_mass: 0.0
+  hetfrz_immersion_nucleation_tend: 0.1
+  hetfrz_contact_nucleation_tend: 0.1
+  hetfrz_deposition_nucleation_tend: 0.1
   pbl_height : 1.0
   phis : 1.0
 

--- a/components/eamxx/tests/multi-process/dynamics_physics/mam/homme_shoc_cld_spa_p3_rrtmgp_mam4_wetscav/input.yaml
+++ b/components/eamxx/tests/multi-process/dynamics_physics/mam/homme_shoc_cld_spa_p3_rrtmgp_mam4_wetscav/input.yaml
@@ -17,6 +17,10 @@ initial_conditions:
   surf_sens_flux: 0.0
   precip_liq_surf_mass: 0.0
   precip_ice_surf_mass: 0.0
+  hetfrz_immersion_nucleation_tend: 0.1
+  hetfrz_contact_nucleation_tend: 0.1
+  hetfrz_deposition_nucleation_tend: 0.1
+
   #variables needed by mam4_wetscav
   #--surface fluxes
   wetdep_hydrophilic_bc: 1e-5 # wet deposition of hydrophilic black carbon [kg/m2/s]

--- a/components/eamxx/tests/multi-process/dynamics_physics/model_restart/input_baseline.yaml
+++ b/components/eamxx/tests/multi-process/dynamics_physics/model_restart/input_baseline.yaml
@@ -17,6 +17,9 @@ initial_conditions:
   surf_sens_flux: 0.0
   precip_liq_surf_mass: 0.0
   precip_ice_surf_mass: 0.0
+  hetfrz_immersion_nucleation_tend: 0.1
+  hetfrz_contact_nucleation_tend: 0.1
+  hetfrz_deposition_nucleation_tend: 0.1
   aero_g_sw: 0.0
   aero_ssa_sw: 0.0
   aero_tau_sw: 0.0

--- a/components/eamxx/tests/multi-process/physics_only/atm_proc_subcycling/input.yaml
+++ b/components/eamxx/tests/multi-process/physics_only/atm_proc_subcycling/input.yaml
@@ -47,6 +47,9 @@ initial_conditions:
   surf_sens_flux: 0.0
   precip_ice_surf_mass: 0.0
   precip_liq_surf_mass: 0.0
+  hetfrz_immersion_nucleation_tend: 0.1
+  hetfrz_contact_nucleation_tend: 0.1
+  hetfrz_deposition_nucleation_tend: 0.1
 
 # The parameters for I/O control
 Scorpio:

--- a/components/eamxx/tests/multi-process/physics_only/mam/p3_mam4_wetscav/input.yaml
+++ b/components/eamxx/tests/multi-process/physics_only/mam/p3_mam4_wetscav/input.yaml
@@ -50,6 +50,9 @@ initial_conditions:
   #variable required for p3
   precip_ice_surf_mass: 0.0
   precip_liq_surf_mass: 0.0
+  hetfrz_immersion_nucleation_tend: 0.1
+  hetfrz_contact_nucleation_tend: 0.1
+  hetfrz_deposition_nucleation_tend: 0.1
 
 # The parameters for I/O control
 Scorpio:

--- a/components/eamxx/tests/multi-process/physics_only/mam/shoc_cldfrac_mam4_aci_p3/input.yaml
+++ b/components/eamxx/tests/multi-process/physics_only/mam/shoc_cldfrac_mam4_aci_p3/input.yaml
@@ -34,6 +34,7 @@ atmosphere_processes:
       Ckm: 0.1
     mam4_aci:
       wsubmin: 0.001
+      enable_aero_vertical_mix: true
       top_level_mam4xx: 6
 
 grids_manager:

--- a/components/eamxx/tests/multi-process/physics_only/mam/shoc_cldfrac_mam4_aci_p3/input.yaml
+++ b/components/eamxx/tests/multi-process/physics_only/mam/shoc_cldfrac_mam4_aci_p3/input.yaml
@@ -59,6 +59,9 @@ initial_conditions:
   #variable required for p3
   precip_ice_surf_mass: 0.0
   precip_liq_surf_mass: 0.0
+  hetfrz_immersion_nucleation_tend: 0.1
+  hetfrz_contact_nucleation_tend: 0.1
+  hetfrz_deposition_nucleation_tend: 0.1
 
   #variables required for mam4_aci
   dgnum: 1e-3

--- a/components/eamxx/tests/multi-process/physics_only/mam/shoc_cldfrac_mam4_aci_p3_mam4_optics_rrtmgp/input.yaml
+++ b/components/eamxx/tests/multi-process/physics_only/mam/shoc_cldfrac_mam4_aci_p3_mam4_optics_rrtmgp/input.yaml
@@ -18,6 +18,7 @@ atmosphere_processes:
     number_of_subcycles: ${MAC_MIC_SUBCYCLES}
     mam4_aci:
       wsubmin: 0.001
+      enable_aero_vertical_mix: true
       top_level_mam4xx: 6
     p3:
       max_total_ni: 740.0e3

--- a/components/eamxx/tests/multi-process/physics_only/mam/shoc_cldfrac_mam4_aci_p3_mam4_optics_rrtmgp/input.yaml
+++ b/components/eamxx/tests/multi-process/physics_only/mam/shoc_cldfrac_mam4_aci_p3_mam4_optics_rrtmgp/input.yaml
@@ -81,6 +81,9 @@ initial_conditions:
   #variables required for p3
   precip_ice_surf_mass: 0.0
   precip_liq_surf_mass: 0.0
+  hetfrz_immersion_nucleation_tend: 0.1
+  hetfrz_contact_nucleation_tend: 0.1
+  hetfrz_deposition_nucleation_tend: 0.1
 
   #variables required for mam4_aci
   dgnum: 1e-3

--- a/components/eamxx/tests/multi-process/physics_only/mam/shoc_cldfrac_mam4_aci_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/multi-process/physics_only/mam/shoc_cldfrac_mam4_aci_p3_rrtmgp/input.yaml
@@ -68,7 +68,10 @@ initial_conditions:
   #variables required for p3
   precip_ice_surf_mass: 0.0
   precip_liq_surf_mass: 0.0
-  
+  hetfrz_immersion_nucleation_tend: 0.1
+  hetfrz_contact_nucleation_tend: 0.1
+  hetfrz_deposition_nucleation_tend: 0.1
+
   #variables required for rrtmgp
   aero_g_sw: 0.0
   aero_ssa_sw: 0.0

--- a/components/eamxx/tests/multi-process/physics_only/mam/shoc_cldfrac_mam4_aci_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/multi-process/physics_only/mam/shoc_cldfrac_mam4_aci_p3_rrtmgp/input.yaml
@@ -18,6 +18,7 @@ atmosphere_processes:
     number_of_subcycles: ${MAC_MIC_SUBCYCLES}
     mam4_aci:
       wsubmin: 0.001
+      enable_aero_vertical_mix: true
       top_level_mam4xx: 6
     p3:
       max_total_ni: 740.0e3

--- a/components/eamxx/tests/multi-process/physics_only/mam/shoc_cldfrac_p3_wetscav/input.yaml
+++ b/components/eamxx/tests/multi-process/physics_only/mam/shoc_cldfrac_p3_wetscav/input.yaml
@@ -58,7 +58,7 @@ initial_conditions:
   wetdep_dust_bin2: 1e-5 # wet deposition of dust (bin2) [kg/m2/s]
   wetdep_dust_bin3: 1e-5 # wet deposition of dust (bin3) [kg/m2/s]
   wetdep_dust_bin4: 1e-5 # wet deposition of dust (bin4) [kg/m2/s]
-  
+
   #variable required for shoc
   surf_sens_flux: 0.0
   surf_evap: 0.0
@@ -66,6 +66,9 @@ initial_conditions:
   #variable required for p3
   precip_ice_surf_mass: 0.0
   precip_liq_surf_mass: 0.0
+  hetfrz_immersion_nucleation_tend: 0.1
+  hetfrz_contact_nucleation_tend: 0.1
+  hetfrz_deposition_nucleation_tend: 0.1
 
 # The parameters for I/O control
 Scorpio:

--- a/components/eamxx/tests/multi-process/physics_only/mam/shoc_mam4_aci/input.yaml
+++ b/components/eamxx/tests/multi-process/physics_only/mam/shoc_mam4_aci/input.yaml
@@ -18,6 +18,7 @@ atmosphere_processes:
     number_of_subcycles: ${MAC_MIC_SUBCYCLES}
     mam4_aci:
       wsubmin: 0.001
+      enable_aero_vertical_mix: true
       top_level_mam4xx: 6
     shoc:
       lambda_low: 0.001

--- a/components/eamxx/tests/multi-process/physics_only/shoc_cld_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/multi-process/physics_only/shoc_cld_p3_rrtmgp/input.yaml
@@ -64,8 +64,11 @@ initial_conditions:
   aero_ssa_sw: 0.0
   aero_tau_sw: 0.0
   aero_tau_lw: 0.0
+  hetfrz_immersion_nucleation_tend: 0.1
+  hetfrz_contact_nucleation_tend: 0.1
+  hetfrz_deposition_nucleation_tend: 0.1
 
 # The parameters for I/O control
 Scorpio:
-  output_yaml_files: ["output.yaml"]
+ output_yaml_files: ["output.yaml"]
 ...

--- a/components/eamxx/tests/multi-process/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
+++ b/components/eamxx/tests/multi-process/physics_only/shoc_cld_spa_p3_rrtmgp/input.yaml
@@ -60,6 +60,9 @@ initial_conditions:
   surf_sens_flux: 0.0
   precip_liq_surf_mass: 0.0
   precip_ice_surf_mass: 0.0
+  hetfrz_immersion_nucleation_tend: 0.1
+  hetfrz_contact_nucleation_tend: 0.1
+  hetfrz_deposition_nucleation_tend: 0.1
 
 # The parameters for I/O control
 Scorpio:

--- a/components/eamxx/tests/multi-process/physics_only/shoc_p3_nudging/input_nudging.yaml
+++ b/components/eamxx/tests/multi-process/physics_only/shoc_p3_nudging/input_nudging.yaml
@@ -53,6 +53,9 @@ initial_conditions:
   surf_sens_flux: 0.0
   precip_ice_surf_mass: 0.0
   precip_liq_surf_mass: 0.0
+  hetfrz_immersion_nucleation_tend: 0.1
+  hetfrz_contact_nucleation_tend: 0.1
+  hetfrz_deposition_nucleation_tend: 0.1
 
 # The parameters for I/O control
 Scorpio:

--- a/components/eamxx/tests/multi-process/physics_only/shoc_p3_nudging/input_nudging_glob_novert.yaml
+++ b/components/eamxx/tests/multi-process/physics_only/shoc_p3_nudging/input_nudging_glob_novert.yaml
@@ -54,6 +54,9 @@ initial_conditions:
   surf_sens_flux: 0.0
   precip_ice_surf_mass: 0.0
   precip_liq_surf_mass: 0.0
+  hetfrz_immersion_nucleation_tend: 0.1
+  hetfrz_contact_nucleation_tend: 0.1
+  hetfrz_deposition_nucleation_tend: 0.1
 
 # The parameters for I/O control
 Scorpio:

--- a/components/eamxx/tests/multi-process/physics_only/shoc_p3_nudging/input_source_data.yaml
+++ b/components/eamxx/tests/multi-process/physics_only/shoc_p3_nudging/input_source_data.yaml
@@ -45,6 +45,9 @@ initial_conditions:
   surf_sens_flux: 0.0
   precip_ice_surf_mass: 0.0
   precip_liq_surf_mass: 0.0
+  hetfrz_immersion_nucleation_tend: 0.1
+  hetfrz_contact_nucleation_tend: 0.1
+  hetfrz_deposition_nucleation_tend: 0.1
 
 # The parameters for I/O control
 Scorpio:

--- a/components/eamxx/tests/single-process/mam/aero_microphys/input.yaml
+++ b/components/eamxx/tests/single-process/mam/aero_microphys/input.yaml
@@ -60,6 +60,15 @@ initial_conditions:
   wetdens: [1038.67760516297, 1046.20002003441, 1031.74623165457, 1086.79731859184]
   nevapr: 0.0
   precip_total_tend: 0.0  
+  surf_radiative_T: 288.0
+  ps: 105000.0
+  horiz_winds: [-0.24988988196194634E+000, -0.23959782871450760E+000]
+  precip_liq_surf_mass: 0.1
+  precip_ice_surf_mass: 0.1
+  snow_depth_land: 0.01
+  fraction_landuse: 0.0
+  SW_flux_dn: 500.0
+  constituent_fluxes: 0.0
 # The parameters for I/O control
 Scorpio:
   output_yaml_files: ["output.yaml"]


### PR DESCRIPTION
An existing EAMxx interface (eamxx_mam_microphysics_process_interface.cpp) is modified to include the invocation of the dry deposition for gases.

Since the CMake option, SCREAM_ENABLE_MAM, is always ON, these codes are always compiled with the EAMxx codebase, but this interface can be turned off/on using the namelist flags.

[non-BFB] for EAMxx cases

-------

### Output variables
This process computes dry deposition fluxes (`dflx`) that are used to update constituent_fluxes.

### Testing
We have existing tests for this interface, so we didn't add any new tests. We have a suite of validation tests in the MAM4xx repo to validate sethet process

The `atmchange` command to invoke this process in a CIME simulation is:

`./atmchange physics::atm_procs_list="mac_aero_mic,rrtmgp,mam4_aero_microphys`

To set up a test with the above configuration, use the following commands:

```
cd cime/scripts
./create_test SMS_D_P32x1_Ln5.ne4pg2_oQU480.F2010-SCREAMv1-MPASSI.<machine>_<compiler>.scream-mam4xx-aero_microphysics -t <test id> -p <project id>
```
Where,
`<machine>` is the machine name
`<compiler>` is the compiler to use on the machine
`<test id >`is a unique string test identifier
`<project id>` is the allocation project to charge

`scream-mam4xx-aero_microphysics` is the test modifier that adds `mam4_aero_microphys` to the `atm_procs_list` process list and increases the number of tracers to 41.

For `ne30pg2` grid, use the following command:
```
./create_test SMS_D_P32x1.ne30pg2_oECv.F2010-SCREAMv1-MPASSI.<machine>_<compiler>.scream-mam4xx-aero_microphysics -t <test id> -p <project id> 
```
### New input data
No new input data

### Figures from model analysis
Coming soon

### Standalone Test Timings (Compy):
We will upload the timings once the PR is reviewed and approved